### PR TITLE
Add wasm wrapper for web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "rayon",
+ "serde",
  "thiserror",
  "tree-sitter",
  "tree-sitter-jinja2",
@@ -317,6 +318,26 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rayon = { version = "1.5.1", optional = true }
 tree-sitter = "0.20.8"
 tree-sitter-jinja2 = { git = "https://github.com/dbt-labs/tree-sitter-jinja2", tag = "v0.2.0" }
 thiserror = "2.0.12"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 quickcheck = "1"
@@ -32,3 +33,4 @@ quickcheck_macros = "1"
 default = ["python", "threads"]
 python = ["pyo3"]
 threads = ["rayon"]
+wasm = ["serde"]

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,8 +1,11 @@
 use crate::extractor::ExprType;
 use std::str::Utf8Error;
 use thiserror::Error;
+#[cfg(feature = "wasm")]
+use serde::Serialize;
 
 // Top-level error type in the hierarchy
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum ParseError {
     #[error("Source Error: {0}")]
@@ -12,6 +15,7 @@ pub enum ParseError {
 }
 
 // Errors from tree-sitter -> ExprU
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum SourceError {
     #[error("Syntax error in source")]
@@ -29,6 +33,7 @@ pub enum SourceError {
 }
 
 // errors from ExprU -> ExprT
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum TypeError {
     #[error("{0} cannot be assigned a {1}")]

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -1,4 +1,6 @@
 use crate::exceptions::{ParseError, SourceError, TypeError};
+#[cfg(feature = "wasm")]
+use serde::Serialize;
 #[cfg(test)]
 use quickcheck::{Arbitrary, Gen};
 #[cfg(feature = "threads")]
@@ -11,6 +13,7 @@ use RefVersion::*;
 
 // final result
 // this is snug fit for the shape of the data
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Extraction {
     pub refs: Vec<DbtRef>,
@@ -111,6 +114,7 @@ enum ExprT {
 }
 
 // wrappers for config return types
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ConfigVal {
     StringC(String),
@@ -149,6 +153,7 @@ impl Arbitrary for ConfigVal {
     }
 }
 
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct DbtRef {
     pub name: String,
@@ -156,6 +161,7 @@ pub struct DbtRef {
     pub version: Option<RefVersion>,
 }
 
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum RefVersion {
     StringRV(String),
@@ -218,6 +224,7 @@ impl Arbitrary for DbtRef {
 
 // values that represent types
 // generally used to pass type information to exceptions
+#[cfg_attr(feature = "wasm", derive(Serialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ExprType {
     String,

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "dbt-extractor-wasm"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+dbt-extractor = { path = "..", default-features = false, features = ["wasm"] }
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.5"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,8 @@
+use wasm_bindgen::prelude::*;
+use dbt_extractor::extract_from_source;
+
+#[wasm_bindgen]
+pub fn extract_from_source_js(src: &str) -> JsValue {
+    let extraction = extract_from_source(src.as_bytes());
+    serde_wasm_bindgen::to_value(&extraction).unwrap()
+}

--- a/wasm/worker.js
+++ b/wasm/worker.js
@@ -1,0 +1,7 @@
+import init, { extract_from_source_js } from './pkg/dbt_extractor_wasm.js';
+
+self.onmessage = async (e) => {
+  await init();
+  const result = extract_from_source_js(e.data);
+  self.postMessage(result);
+};


### PR DESCRIPTION
## Summary
- add optional `serde` feature and `wasm` flag to library
- derive `Serialize` for extraction data structures and errors when the `wasm` feature is enabled
- introduce a new `wasm` crate exposing `extract_from_source_js`
- example `worker.js` demonstrates loading the wasm module

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68540d495c248321b78595fe158bdd71