### PR TITLE
Add WASM browser usage docs and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ The parser is solely responsible for turning text into recognized values, while 
 
 The extractor uses the typed abstract syntax tree to easily identify all the refs, sources, and configs present and extract them.
 
+## Running in the Browser
+
+Build the WebAssembly package with `wasm-pack`:
+
+```bash
+wasm-pack build wasm --target web
+```
+
+This generates a `wasm/pkg/` directory containing the module ready for use from
+`wasm/worker.js`, which exposes `extract_from_source_js` to a web worker.
+
+When compiling with the `wasm` feature the default `threads` feature is
+disabled, so extraction runs single-threaded and parallel processing is not
+available.
+
+A minimal example using the worker can be found in [wasm/demo](wasm/demo).
+
 ## Join the dbt Community
 
 - Be part of the conversation in the [dbt Community Slack](http://community.getdbt.com/)

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["cdylib"]
 dbt-extractor = { path = "..", default-features = false, features = ["wasm"] }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.5"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/wasm/demo/index.html
+++ b/wasm/demo/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>dbt-extractor wasm demo</title>
+</head>
+<body>
+  <textarea id="input" rows="5" cols="60">select * from {{ ref('my_table') }}</textarea>
+  <pre id="output"></pre>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/wasm/demo/main.js
+++ b/wasm/demo/main.js
@@ -1,0 +1,16 @@
+const worker = new Worker('../worker.js', { type: 'module' });
+
+const input = document.getElementById('input');
+const output = document.getElementById('output');
+
+function run() {
+  worker.postMessage(input.value);
+}
+
+worker.onmessage = (e) => {
+  output.textContent = JSON.stringify(e.data, null, 2);
+};
+
+input.addEventListener('input', run);
+run();
+

--- a/wasm/tests/extract.rs
+++ b/wasm/tests/extract.rs
@@ -1,0 +1,24 @@
+use dbt_extractor_wasm::extract_from_source_js;
+use dbt_extractor::{Extraction, DbtRef};
+use serde_wasm_bindgen::from_value;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn extract_from_source_js_returns_expected() {
+    let js_val = extract_from_source_js("{{ ref('my_table') }}");
+    let result: Extraction = from_value(js_val).unwrap();
+    assert_eq!(
+        result,
+        Extraction::populate(
+            Some(vec![DbtRef {
+                name: "my_table".to_string(),
+                package: None,
+                version: None,
+            }]),
+            None,
+            None,
+        )
+    );
+}


### PR DESCRIPTION
## Summary
- document using `dbt-extractor` in the browser
- add a minimal demo with HTML and JS
- add a small wasm test

## Testing
- `cargo test`
- `wasm-pack test --node wasm` *(fails: could not download wasm target)*

------
https://chatgpt.com/codex/tasks/task_e_68541e76a8d08321acf0dbb8ec9af40c